### PR TITLE
vxlayout: add vxlayout package

### DIFF
--- a/vxlayout/box.go
+++ b/vxlayout/box.go
@@ -1,0 +1,69 @@
+package vxlayout
+
+import (
+	"git.sr.ht/~rockorager/vaxis"
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+	"github.com/avidal/vxexp"
+)
+
+// Constrained is a [vxfw.Widget] that constrains a widget by min and max size.
+// Min and max are pointers to [vxfw.Size] so that the caller can indicate a lack of constraint.
+// If either axis of size is 0, that axis is ignored for constraint purposes.
+// Constrained can be useful for laying out a Row where you want to ensure a maximum height.
+func Constrained(widget vxfw.Widget, minSize, maxSize *vxfw.Size) vxfw.Widget {
+	return vxexp.WidgetFunc(func(ctx vxfw.DrawContext) (vxfw.Surface, error) {
+		if minSize != nil {
+			if minSize.Width > ctx.Min.Width {
+				ctx.Min.Width = minSize.Width
+			}
+			if minSize.Height > ctx.Min.Height {
+				ctx.Min.Height = minSize.Height
+			}
+		}
+		if maxSize != nil {
+			if maxSize.Width != 0 && maxSize.Width < ctx.Max.Width {
+				ctx.Max.Width = maxSize.Width
+			}
+			if maxSize.Height != 0 && maxSize.Height < ctx.Max.Height {
+				ctx.Max.Height = maxSize.Height
+			}
+		}
+
+		return widget.Draw(ctx)
+	})
+}
+
+// Sized is a [vxfw.Widget] that passes a fixed size to its child widget as long as size fits the
+// incoming constraints. If either axis of size is 0, that size is ignored.
+// This can be used to place a widget that normally cannot be unconstrained (such as an infinite
+// list) into a flexible layout. See also [Limited].
+// This is a shortcut for Constrained(widget, size, size)
+func Sized(widget vxfw.Widget, size vxfw.Size) vxfw.Widget {
+	return Constrained(widget, &size, &size)
+}
+
+// Limited is a [vxfw.Widget] that limits its child by size only if the incoming constraint is
+// unlimited. If either axis of size is 0, that axis is ignored.
+func Limited(widget vxfw.Widget, size vxfw.Size) vxfw.Widget {
+	return vxexp.WidgetFunc(func(ctx vxfw.DrawContext) (vxfw.Surface, error) {
+		if ctx.Max.HasUnboundedWidth() && size.Width > 0 {
+			ctx.Max.Width = size.Width
+		}
+		if ctx.Max.HasUnboundedHeight() && size.Height > 0 {
+			ctx.Max.Height = size.Height
+		}
+
+		return widget.Draw(ctx)
+	})
+}
+
+// Fill returns a [vxfw.Widget] that fills its space with the supplied cell.
+// Note that Fill will take all available space. It's primarily useful to diagnose layouts, and
+// will usually be contained in a [Flexible]
+func Fill(cell vaxis.Cell) vxfw.Widget {
+	return vxexp.WidgetFunc(func(ctx vxfw.DrawContext) (vxfw.Surface, error) {
+		surface := vxfw.NewSurface(ctx.Max.Width, ctx.Max.Height, nil)
+		surface.Fill(cell)
+		return surface, nil
+	})
+}

--- a/vxlayout/flex.go
+++ b/vxlayout/flex.go
@@ -1,0 +1,263 @@
+package vxlayout
+
+import (
+	"math"
+
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+)
+
+// Determines how children in a [Row] or [Column] are laid out on the cross axis.
+// The default is [CrossAxisCenter], which centers children in the available cross axis space.
+// Use [CrossAxisStart] to align children to the top of a [Row] or left of a [Column], and vice
+// versa for [CrossAxisEnd].
+// [CrossAxisStretch] will force all children to fill the maximum space on the cross axis.
+type CrossAxisAlignment int
+
+const (
+	CrossAxisCenter CrossAxisAlignment = iota
+	CrossAxisStart
+	CrossAxisEnd
+	CrossAxisStretch
+)
+
+// Determines how children in a [Row] or [Column] are laid out on the main axis.
+// The default is [MainAxisStart], which places children at the left or top of a [Row] or [Column]
+// respectively.
+// Use [MainAxisCenter] to center children, or one of the Space variants to distribute the space
+// elsewhere.
+// Note that these options do nothing if one of the children has a flex factor > 0, as those
+// children will take the available space.
+type MainAxisAlignment int
+
+const (
+	MainAxisStart MainAxisAlignment = iota
+	MainAxisEnd
+	MainAxisCenter
+	MainAxisSpaceBetween
+	MainAxisSpaceAround
+	MainAxisSpaceEvenly
+)
+
+type Options struct {
+	MainAxis  MainAxisAlignment
+	CrossAxis CrossAxisAlignment
+
+	// Gap controls how much space is placed between each child before the children are sized.
+	Gap uint16
+}
+
+// Row returns a [vxfw.Widget] that lays out children horizontally.
+func Row(children []vxfw.Widget, options Options) vxfw.Widget {
+	return &flex{children: children, options: options, orientation: Horizontal}
+}
+
+// Column returns a [vxfw.Widget] that lays out children vertically.
+func Column(children []vxfw.Widget, options Options) vxfw.Widget {
+	return &flex{children: children, options: options, orientation: Vertical}
+}
+
+type flex struct {
+	children []vxfw.Widget
+	options  Options
+
+	orientation Orientation
+}
+
+var _ vxfw.Widget = flex{}
+
+func (f flex) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
+	var totalFlex, maxCross uint16
+	surfaces := make([]vxfw.Surface, len(f.children))
+	used := f.options.Gap * uint16(len(f.children)-1)
+	maxMain := f.orientation.MainAxis(ctx.Max)
+
+	// First pass, lay out all non flexible children.
+	// Determine how much space they've used on the main axis, and the largest size on the
+	// cross axis.
+	for i, child := range f.children {
+		if c, ok := child.(flexible); ok {
+			// If the flex factor is 0, this is the same as being intrinsically sized
+			factor := c.FlexFactor()
+			if factor > 0 {
+				totalFlex += factor
+				continue
+			}
+		}
+
+		surface, err := child.Draw(instrinsicConstraint(ctx, f.orientation, f.options.CrossAxis))
+		if err != nil {
+			return vxfw.Surface{}, err
+		}
+
+		surfaces[i] = surface
+		used += f.orientation.MainAxis(surface.Size)
+		maxCross = f.orientation.CrossMax(surface.Size, maxCross)
+	}
+
+	// The remaining space is divided among flexible children
+	remaining := maxMain - used
+
+	for i, child := range f.children {
+		c, ok := child.(flexible)
+		// Non-flexible children, or children with a flex factor of 0, were laid out in the
+		// first pass above.
+		if !ok || c.FlexFactor() == 0 {
+			continue
+		}
+
+		size := uint16(0)
+
+		if i == len(f.children)-1 {
+			// last child gets all of the remaining space
+			// NOTE: This is calculated from the space used in this layout pass
+			// Whereas flex unit distribution is calculated based on what was remaining
+			// after the first pass was completed
+			size = maxMain - used
+		} else {
+			// otherwise, size is based on the flex factor
+			size = (remaining * c.FlexFactor()) / totalFlex
+		}
+
+		// If c is FlexLoose, we loosen the minimum constraint to 0
+		// Otherwise (the default), the child must take a tight constraint
+		cons := flexibleConstraint(ctx, f.orientation, f.options.CrossAxis, size)
+		if c.FlexLoose() {
+			cons = f.orientation.Loosen(cons)
+		} else {
+			cons = f.orientation.Tighten(cons)
+		}
+
+		surface, err := c.Draw(cons)
+		if err != nil {
+			return vxfw.Surface{}, err
+		}
+
+		surfaces[i] = surface
+		used += f.orientation.MainAxis(surface.Size)
+		maxCross = f.orientation.CrossMax(surface.Size, maxCross)
+	}
+
+	// We have all of our surfaces, we know our constraints, it's time to finalize the layout.
+	// Each child is placed within the parent surface based on the layout options.
+	// TODO: Implement MainAxisSize option which allows the main axis to take min (size of all
+	// children) or max. For now, we'll always use the max.
+	// Note that even if we implement min main axis size, it becomes irrelevant if any of the
+	// children are flexible (and not loose)
+	size := f.orientation.Size(maxMain, maxCross)
+	surface := vxfw.Surface{
+		Size:     size,
+		Children: make([]vxfw.SubSurface, len(surfaces)),
+	}
+
+	/*
+		Distribution.
+
+		First, apply f.options.Gap *between* each child
+		If main axis start, no other adjustments
+		if main axis end, offset starts at remaining
+		If main axis center, offset starts at remaining / 2
+		If main axis space between, gap increases by remaining / (len(children)-1)
+		If main axis space around, gap increases by remaining / len(children), offset starts at gap / 2
+		If main axis space evenly, gap increases by remaining / len(children)+1, offset starts at gap
+
+		Cross offset is simpler:
+
+		if cross axis start, offset is 0
+		if cross axis end, offset is max cross - child cross
+		if cross axis center, offset is (max cross - child cross) / 2
+		if cross axis stretch, offset is 0 (child is already tight in the cross axis)
+	*/
+
+	remaining = maxMain - used
+	var offset, gap uint16
+	var nchildren uint16 = uint16(len(f.children))
+
+	gap = f.options.Gap
+
+	switch f.options.MainAxis {
+	case MainAxisEnd:
+		offset = remaining
+	case MainAxisCenter:
+		offset = remaining / 2
+	case MainAxisSpaceBetween:
+		// Place all remaining space between the children
+		gap += remaining / (nchildren - 1)
+	case MainAxisSpaceAround:
+		// Place all remaining space between children, with half that space on each end
+		chunk := remaining / nchildren
+		gap += chunk
+		offset = chunk / 2
+	case MainAxisSpaceEvenly:
+		// Place all remaining space between, before, and after children equally
+		chunk := remaining / (nchildren + 1)
+		gap += chunk
+		offset = chunk
+	}
+
+	// Iterate over children, applying spacing and distribution options
+	var cross uint16
+	for i, child := range surfaces {
+		// If this is not the first child, add gap to offset
+		if i > 0 {
+			offset += gap
+		}
+
+		cross = 0
+		switch f.options.CrossAxis {
+		case CrossAxisEnd:
+			cross = maxCross - f.orientation.CrossAxis(child.Size)
+		case CrossAxisCenter:
+			cross = (maxCross - f.orientation.CrossAxis(child.Size)) / 2
+		}
+
+		origin := f.orientation.Origin(int(offset), int(cross))
+		surface.Children[i] = vxfw.SubSurface{
+			Origin:  origin,
+			Surface: child,
+		}
+
+		offset += f.orientation.MainAxis(child.Size)
+	}
+
+	return surface, nil
+}
+
+// instrinsicConstraint takes a [vxfw.DrawContext] and returns a new one with the main axis
+// unbound, and the cross axis adjusted based on the crossalign.
+// This constraint is used to compute instrinsic sizes of non-[Flexible] children in the first
+// layout pass.
+func instrinsicConstraint(ctx vxfw.DrawContext, o Orientation, crossalign CrossAxisAlignment) vxfw.DrawContext {
+	out := vxfw.DrawContext(ctx)
+	switch o {
+	case Horizontal:
+		out.Max.Width = math.MaxUint16
+		if crossalign == CrossAxisStretch {
+			out.Min.Height = out.Max.Height
+		}
+	case Vertical:
+		out.Max.Height = math.MaxUint16
+		if crossalign == CrossAxisStretch {
+			out.Min.Width = out.Max.Width
+		}
+	}
+	return out
+}
+
+// flexibleConstraint is like [instrinsicConstraint] but sets the main axis to the specified size.
+// This is used to layout a flexible child after determining its portion of the available space.
+func flexibleConstraint(ctx vxfw.DrawContext, o Orientation, crossalign CrossAxisAlignment, size uint16) vxfw.DrawContext {
+	out := vxfw.DrawContext(ctx)
+	switch o {
+	case Horizontal:
+		out.Max.Width = size
+		if crossalign == CrossAxisStretch {
+			out.Min.Height = out.Max.Height
+		}
+	case Vertical:
+		out.Max.Height = size
+		if crossalign == CrossAxisStretch {
+			out.Min.Width = out.Max.Width
+		}
+	}
+	return out
+}

--- a/vxlayout/flex_test.go
+++ b/vxlayout/flex_test.go
@@ -1,0 +1,129 @@
+package vxlayout
+
+import (
+	"testing"
+
+	"git.sr.ht/~rockorager/vaxis"
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+	"git.sr.ht/~rockorager/vaxis/vxfw/text"
+)
+
+func TestFlexRow(t *testing.T) {
+	layout := Row([]vxfw.Widget{
+		text.New("abc"),
+		Expanded(text.New("def"), 1),
+		Expanded(text.New("ghi"), 1),
+		Expanded(text.New("jkl\nnmo"), 1),
+	}, Options{})
+
+	ctx := vxfw.DrawContext{Max: vxfw.Size{Width: 16, Height: 16}, Characters: vaxis.Characters}
+	surface, err := layout.Draw(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if surface.Size.Width != 16 {
+		t.Logf("wrong flex width, got=%d, want=16", surface.Size.Width)
+		t.Fail()
+	}
+
+	if surface.Size.Height != 2 {
+		t.Logf("wrong flex height, got=%d, want=2", surface.Size.Height)
+		t.Fail()
+	}
+
+	if len(surface.Children) != 4 {
+		t.Logf("wrong number of flex children, got=%d, want=4", len(surface.Children))
+		t.Fail()
+	}
+
+	// col moves forward by the width of each child, used to assert origins
+	col := 0
+
+	// expected widths of each child
+	// first child should be 3 since it's not flexible
+	// remaining 3 children have equal flex and share the remaining (16-3) columns
+	// since 13 / 3 is 4 that leaves 1 extra which is assigned to the last child
+	widths := []uint16{
+		3,
+		3 + 1,
+		3 + 1,
+		3 + 1 + 1,
+	}
+
+	for i, want := range widths {
+		child := surface.Children[i]
+
+		got := child.Surface.Size.Width
+		if got != want {
+			t.Logf("wrong width for child %d, got=%d, want=%d", i, got, want)
+			t.Fail()
+		}
+		if child.Origin.Col != col {
+			t.Logf("wrong origin for child %d, got=%d, want=%d", i, child.Origin.Col, col)
+			t.Fail()
+		}
+		col += int(want)
+	}
+}
+
+func TestFlexColumn(t *testing.T) {
+	// Wrap Column in Constrained so Space doesn't take all 16 columns wide
+	layout := Constrained(Column([]vxfw.Widget{
+		text.New("abc"),
+		Expanded(text.New("def"), 1),
+		Space(1),
+		Expanded(text.New("jkl\nnmo"), 2),
+	}, Options{}), nil, &vxfw.Size{Width: 3})
+
+	ctx := vxfw.DrawContext{Max: vxfw.Size{Width: 16, Height: 16}, Characters: vaxis.Characters}
+	surface, err := layout.Draw(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if surface.Size.Width != 3 {
+		t.Logf("wrong flex width, got=%d, want=3", surface.Size.Width)
+		t.Fail()
+	}
+
+	if surface.Size.Height != 16 {
+		t.Logf("wrong flex height, got=%d, want=16", surface.Size.Height)
+		t.Fail()
+	}
+
+	if len(surface.Children) != 4 {
+		t.Logf("wrong number of flex children, got=%d, want=4", len(surface.Children))
+		t.Fail()
+	}
+
+	// row moves forward by the height of each child, used to assert origins
+	row := 0
+
+	// first child is not flexible, so it takes 1 row, leaving 15 to distribute
+	// 2 and 3 are both flex 1, 4 is flex 2 so it takes as much available space
+	// as the others.
+	// 15 / 4 == 3 (+3 leftover), giving 3, 3, and 3+3 (flex 2) + leftover 3 to the last
+	// child.
+	heights := []uint16{
+		1,
+		3,
+		3,
+		9,
+	}
+
+	for i, want := range heights {
+		child := surface.Children[i]
+
+		got := child.Surface.Size.Height
+		if got != want {
+			t.Logf("wrong height for child %d, got=%d, want=%d", i, got, want)
+			t.Fail()
+		}
+		if child.Origin.Row != row {
+			t.Logf("wrong origin for child %d, got=%d, want=%d", i, child.Origin.Row, row)
+			t.Fail()
+		}
+		row += int(want)
+	}
+}

--- a/vxlayout/flexbox.go
+++ b/vxlayout/flexbox.go
@@ -1,0 +1,60 @@
+package vxlayout
+
+import (
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+	"github.com/avidal/vxexp"
+)
+
+type flexible interface {
+	vxfw.Widget
+
+	// FlexFactor determines how much of the available space is proportioned to this widget
+	FlexFactor() uint16
+	// A loosely flexible widget may take less than its proportioned flex space.
+	// [Flexible] is a widget that provides a loose fit to its child.
+	FlexLoose() bool
+}
+
+// Expanded returns a [vxfw.Widget] that will expand in a flexible layout based on flex.
+// Note that a flex of 0 means the widget will not be flexible at all and is typically a sign
+// of a bug in your layout.
+func Expanded(widget vxfw.Widget, flex uint16) vxfw.Widget {
+	return flexbox{Widget: widget, flex: flex}
+}
+
+// Flex returns a [vxfw.Widget] that will loosely flex in a flexible layout based on flex.
+// Note that a flex of 0 means the widget will not be flexible at all and is typically a sign
+// of a bug in your layout.
+func Flexible(widget vxfw.Widget, flex uint16) vxfw.Widget {
+	return flexbox{Widget: widget, flex: flex, loose: true}
+}
+
+// Space returns a [vxfw.Widget] that will fill all available space in a flexible layout.
+// Note that a Space(0) has no flex factor and will take ALL space that comes after it in the
+// layout. If flex is > 0 (ie, Space(1)), Space will share remaining space proportionally with
+// other flexible widgets.
+func Space(flex uint16) vxfw.Widget {
+	fn := vxexp.WidgetFunc(func(ctx vxfw.DrawContext) (vxfw.Surface, error) {
+		return vxfw.NewSurface(ctx.Max.Width, ctx.Max.Height, nil), nil
+	})
+
+	return flexbox{Widget: fn, flex: flex}
+}
+
+type flexbox struct {
+	vxfw.Widget
+	flex  uint16
+	loose bool
+}
+
+var (
+	_ vxfw.Widget = flexbox{}
+	_ flexible    = flexbox{}
+)
+
+func (b flexbox) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
+	return b.Widget.Draw(ctx)
+}
+
+func (b flexbox) FlexLoose() bool    { return b.loose }
+func (b flexbox) FlexFactor() uint16 { return b.flex }

--- a/vxlayout/orientation.go
+++ b/vxlayout/orientation.go
@@ -1,0 +1,116 @@
+package vxlayout
+
+import (
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+)
+
+type Orientation int
+
+const (
+	Horizontal Orientation = iota
+	Vertical
+)
+
+// MainAxis returns the MainAxis of size
+func (o Orientation) MainAxis(size vxfw.Size) uint16 {
+	main, _ := o.Axes(size)
+	return main
+}
+
+// CrossAxis returns the cross axis of size
+func (o Orientation) CrossAxis(size vxfw.Size) uint16 {
+	_, cross := o.Axes(size)
+	return cross
+}
+
+// Axes returns the main and cross axes of size.
+func (o Orientation) Axes(size vxfw.Size) (uint16, uint16) {
+	var main, cross uint16
+	switch o {
+	case Horizontal:
+		main = size.Width
+		cross = size.Height
+	case Vertical:
+		main = size.Height
+		cross = size.Width
+	}
+	return main, cross
+}
+
+// CrossMax takes a size and a constraint and returns the max of size or constraint on the cross
+// axis.
+func (o Orientation) CrossMax(size vxfw.Size, constraint uint16) uint16 {
+	if o == Horizontal && size.Height > constraint {
+		return size.Height
+	} else if o == Vertical && size.Width > constraint {
+		return size.Width
+	}
+
+	return constraint
+}
+
+// Size takes main and cross axis and returns a [vxfw.Size] based on orientation
+func (o Orientation) Size(main, cross uint16) vxfw.Size {
+	var out vxfw.Size
+	switch o {
+	case Horizontal:
+		out.Width, out.Height = main, cross
+	case Vertical:
+		out.Height, out.Width = main, cross
+	}
+	return out
+}
+
+// Origin returns a [vxfw.RelativePoint] with main and cross offsets.
+func (o Orientation) Origin(main, cross int) vxfw.RelativePoint {
+	var p vxfw.RelativePoint
+	switch o {
+	case Horizontal:
+		p.Col = main
+		p.Row = cross
+	case Vertical:
+		p.Row = main
+		p.Col = cross
+	}
+	return p
+}
+
+// OffsetOrigin applies main and cross axis offsets to origin and returns a new
+// [vxfw.RelativePoint]
+func (o Orientation) OffsetOrigin(origin vxfw.RelativePoint, main, cross int) vxfw.RelativePoint {
+	var p vxfw.RelativePoint
+	p.Col, p.Row = origin.Col, origin.Row
+	switch o {
+	case Horizontal:
+		p.Col += main
+		p.Row += cross
+	case Vertical:
+		p.Row += main
+		p.Col += cross
+	}
+	return p
+}
+
+// Loosen returns a [vxfw.DrawContext] with the main axis set to 0
+func (o Orientation) Loosen(ctx vxfw.DrawContext) vxfw.DrawContext {
+	out := vxfw.DrawContext(ctx)
+	switch o {
+	case Horizontal:
+		out.Min.Width = 0
+	case Vertical:
+		out.Min.Height = 0
+	}
+	return out
+}
+
+// Tighten returns a [vxfw.DrawContext] with the main axis minimum increased to equal the maximum.
+func (o Orientation) Tighten(ctx vxfw.DrawContext) vxfw.DrawContext {
+	out := vxfw.DrawContext(ctx)
+	switch o {
+	case Horizontal:
+		out.Min.Width = out.Max.Width
+	case Vertical:
+		out.Min.Height = out.Max.Height
+	}
+	return out
+}


### PR DESCRIPTION
This patch introduces several widgets all focused on layout:

Row, Column: flexible layouts for both orientations

Expanded, Flexible: wrap widgets to make them flexible

Constrained, Sized, Limited: control or otherwise influence sizing of a wrapped widget

Space, Fill: take up space in a layout, optionally with a character/style fill